### PR TITLE
Get the html source of messages from html_codesniffer

### DIFF
--- a/lib/sniff/handle-result.js
+++ b/lib/sniff/handle-result.js
@@ -42,7 +42,8 @@ exports.sanitizeMessages = function (messages) {
 		return {
 			code: message.code,
 			message: message.msg,
-			type: messageTypeMap[message.type] || 'unknown'
+			type: messageTypeMap[message.type] || 'unknown',
+			html: message.outerHTML
 		};
 	});
 };

--- a/lib/sniff/run-html-codesniffer.js
+++ b/lib/sniff/run-html-codesniffer.js
@@ -71,7 +71,15 @@ exports = module.exports = function (page, opts, callback) {
 		// Get messages
 		function (next) {
 			page.evaluate(function () {
-				return window.HTMLCS.getMessages();
+				var messages = window.HTMLCS.getMessages();
+				return messages.map(function (message) {
+					return {
+						code: message.code,
+						msg: message.msg,
+						type: message.type,
+						outerHTML: message.element.outerHTML || 'unknown'
+					};
+				});
 			}, function (messages) {
 				next(null, messages);
 			});

--- a/test/unit/sniff/handle-result.js
+++ b/test/unit/sniff/handle-result.js
@@ -79,16 +79,16 @@ describe('sniff/handle-result', function () {
 
 		it('should transform messages as expected', function () {
 			var rawMessages = [
-				{code: 12, msg: 'foo', type: 1},
-				{code: 34, msg: 'bar', type: 2},
-				{code: 56, msg: 'baz', type: 3},
-				{code: 78, msg: 'qux', type: 4}
+				{code: 12, msg: 'foo', type: 1, outerHTML: 'foo'},
+				{code: 34, msg: 'bar', type: 2, outerHTML: 'bar'},
+				{code: 56, msg: 'baz', type: 3, outerHTML: 'baz'},
+				{code: 78, msg: 'qux', type: 4, outerHTML: 'qux'}
 			];
 			var expectedMessages = [
-				{code: 12, message: 'foo', type: 'error'},
-				{code: 34, message: 'bar', type: 'warning'},
-				{code: 56, message: 'baz', type: 'notice'},
-				{code: 78, message: 'qux', type: 'unknown'}
+				{code: 12, message: 'foo', type: 'error', html: 'foo'},
+				{code: 34, message: 'bar', type: 'warning', html: 'bar'},
+				{code: 56, message: 'baz', type: 'notice', html: 'baz'},
+				{code: 78, message: 'qux', type: 'unknown', html: 'qux'}
 			];
 			var sanitizedMessages = handleResult.sanitizeMessages(rawMessages);
 			assert.deepEqual(sanitizedMessages[0], expectedMessages[0]);

--- a/test/unit/sniff/run-html-codesniffer.js
+++ b/test/unit/sniff/run-html-codesniffer.js
@@ -79,7 +79,7 @@ describe('sniff/run-html-codesniffer', function () {
 
 	it('should callback with the resulting HTML CodeSniffer messages', function (done) {
 		runHtmlCodeSniffer(page, opts, function (err, results) {
-			assert.strictEqual(results, messages);
+			assert.deepEqual(results, messages);
 			done();
 		});
 	});


### PR DESCRIPTION
It is sometimes helpful to see the html source of a message returned by html_codensiffer.

I made these changes while trying to locate the source of a message in pa11y.  The message was present in pa11y, but wasn't being reported by html_codesniffer bookmarklet when I ran it in the browser, so I had no idea what the context of the error was.  (it turns out it was because phantomjs thinks it is a touch browser)