### PR TITLE
Get and truncate the html source of messages from html_codesniffer

### DIFF
--- a/lib/sniff/handle-result.js
+++ b/lib/sniff/handle-result.js
@@ -42,7 +42,8 @@ exports.sanitizeMessages = function (messages) {
 		return {
 			code: message.code,
 			message: message.msg,
-			type: messageTypeMap[message.type] || 'unknown'
+			type: messageTypeMap[message.type] || 'unknown',
+			html: message.outerHTML
 		};
 	});
 };

--- a/lib/sniff/run-html-codesniffer.js
+++ b/lib/sniff/run-html-codesniffer.js
@@ -72,12 +72,26 @@ exports = module.exports = function (page, opts, callback) {
 		function (next) {
 			page.evaluate(function () {
 				return window.HTMLCS.getMessages().map(function (message) {
+					var outerHTML;
+					if (message.element.outerHTML) {
+						outerHTML = message.element.outerHTML;
+						if (message.element.innerHTML.length > 31) {
+							var innerHTML = message.element.innerHTML.substr(0, 31) + '...';
+							outerHTML = outerHTML.replace(
+								message.element.innerHTML,
+								innerHTML
+							);
+						}
+					} else {
+						outerHTML = 'unknown';
+					}
+
 					return {
 						code: message.code,
 						data: message.data,
 						msg: message.msg,
 						type: message.type,
-						outerHTML: message.element.outerHTML || 'unknown'
+						outerHTML: outerHTML
 					};
 				});
 			}, function (messages) {

--- a/lib/sniff/run-html-codesniffer.js
+++ b/lib/sniff/run-html-codesniffer.js
@@ -1,15 +1,15 @@
 // This file is part of pa11y.
-// 
+//
 // pa11y is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // pa11y is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with pa11y.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -76,7 +76,8 @@ exports = module.exports = function (page, opts, callback) {
 						code: message.code,
 						data: message.data,
 						msg: message.msg,
-						type: message.type
+						type: message.type,
+						outerHTML: message.element.outerHTML || 'unknown'
 					};
 				});
 			}, function (messages) {

--- a/test/unit/sniff/handle-result.js
+++ b/test/unit/sniff/handle-result.js
@@ -79,16 +79,16 @@ describe('sniff/handle-result', function () {
 
 		it('should transform messages as expected', function () {
 			var rawMessages = [
-				{code: 12, msg: 'foo', type: 1},
-				{code: 34, msg: 'bar', type: 2},
-				{code: 56, msg: 'baz', type: 3},
-				{code: 78, msg: 'qux', type: 4}
+				{code: 12, msg: 'foo', type: 1, outerHTML: 'foo'},
+				{code: 34, msg: 'bar', type: 2, outerHTML: 'bar'},
+				{code: 56, msg: 'baz', type: 3, outerHTML: 'baz'},
+				{code: 78, msg: 'qux', type: 4, outerHTML: 'qux'}
 			];
 			var expectedMessages = [
-				{code: 12, message: 'foo', type: 'error'},
-				{code: 34, message: 'bar', type: 'warning'},
-				{code: 56, message: 'baz', type: 'notice'},
-				{code: 78, message: 'qux', type: 'unknown'}
+				{code: 12, message: 'foo', type: 'error', html: 'foo'},
+				{code: 34, message: 'bar', type: 'warning', html: 'bar'},
+				{code: 56, message: 'baz', type: 'notice', html: 'baz'},
+				{code: 78, message: 'qux', type: 'unknown', html: 'qux'}
 			];
 			var sanitizedMessages = handleResult.sanitizeMessages(rawMessages);
 			assert.deepEqual(sanitizedMessages[0], expectedMessages[0]);

--- a/test/unit/sniff/handle-result.js
+++ b/test/unit/sniff/handle-result.js
@@ -1,15 +1,15 @@
 // This file is part of pa11y.
-// 
+//
 // pa11y is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // pa11y is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with pa11y.  If not, see <http://www.gnu.org/licenses/>.
 


### PR DESCRIPTION
This is basically a rebase of #56 against master plus adding some basic truncation.