### PR TITLE
CSS Selectors

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -13,7 +13,7 @@ Migrating From 1.0 To 2.0
 The command-line interface in 2.0 is similar to 1.0, but there are a few key changes.
 
   - The `console` reporter has been renamed to `cli` and has a different output format
-  - The `csv` reporter now includes the message context
+  - The `csv` reporter now includes the message context and selector
   - The `json` reporter now outputs an array which matches the new [output format](#output-format). You can use the [pa11y JSON 1.0 reporter](https://github.com/nature/pa11y-reporter-1.0-json) to output 1.0-style JSON
   - Reporters no longer handle the way pa11y exits, this is controlled through the new `--level` flag
   - Custom reporters now have a different API, see the [README](README.md) for more information

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -45,6 +45,7 @@ Results in pa11y 2.0 are no longer output as an object, instead only the results
     code: 'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
     context: '<title>Pa11y - Your automated accessib...</title>',
     message: 'Check that the title element describes the document.',
+    selector: 'html > head > title',
     type: 'notice',
     typeCode: 3
 }

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ The results that get passed into your test callback come from HTML CodeSniffer, 
         code: 'WCAG2AA.Principle1.Guideline1_1.1_1_1.H30.2',
         context: '<a href="http://example.com/"><img src="example.jpg" alt=""/></a>',
         message: 'Img element is the only content of the link, but is missing alt text. The alt text should describe the purpose of the link.',
+        selector: 'html > body > p:nth-child(1) > a',
         type: 'error',
         typeCode: 1
     },
@@ -224,6 +225,7 @@ The results that get passed into your test callback come from HTML CodeSniffer, 
         code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
         context: '<b>Hello World!</b>',
         message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
+        selector: '#content > b:nth-child(4)',
         type: 'warning',
         typeCode: 2
     },
@@ -231,6 +233,7 @@ The results that get passed into your test callback come from HTML CodeSniffer, 
         code: 'WCAG2AA.Principle2.Guideline2_4.2_4_4.H77,H78,H79,H80,H81',
         context: '<a href="http://example.com/">Hello World!</a>',
         message: 'Check that the link text combined with programmatically determined link context identifies the purpose of the link.',
+        selector: 'html > body > ul > li:nth-child(2) > a',
         type: 'notice',
         typeCode: 3
     }

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -50,7 +50,8 @@ function injectPa11y (window, options, done) {
 			context: processMessageHtml(message.element),
 			message: message.msg,
 			type: (messageTypeMap[message.type] || 'unknown'),
-			typeCode: message.type
+			typeCode: message.type,
+			selector: getCssSelectorForElement(message.element)
 		};
 	}
 
@@ -69,6 +70,43 @@ function injectPa11y (window, options, done) {
 			outerHTML = outerHTML.substr(0, 250) + '...';
 		}
 		return outerHTML;
+	}
+
+	function getCssSelectorForElement (element, selectorParts) {
+		selectorParts = selectorParts || [];
+		if (element.nodeType === 1) {
+			var identifier = buildElementIdentifier(element);
+			selectorParts.unshift(identifier);
+			if (!element.id && element.parentNode) {
+				return getCssSelectorForElement(element.parentNode, selectorParts);
+			}
+		}
+		return selectorParts.join(' > ');
+	}
+
+	function buildElementIdentifier (element) {
+		var identifier = (element.id ? '#' + element.id : element.tagName.toLowerCase());
+		var siblings = getSiblings(element);
+		var childIndex = siblings.indexOf(element);
+		if (!element.id && !isOnlySiblingOfType(element, siblings) && childIndex !== -1) {
+			identifier += ':nth-child(' + (childIndex + 1) + ')';
+		}
+		return identifier;
+	}
+
+	function getSiblings (element) {
+		return Array.prototype.slice.call(element.parentNode.childNodes).filter(isElementNode);
+	}
+
+	function isOnlySiblingOfType (element, siblings) {
+		var siblingsOfType = siblings.filter(function (sibling) {
+			return (sibling.tagName === element.tagName);
+		});
+		return (siblingsOfType.length <= 1);
+	}
+
+	function isElementNode (element) {
+		return (element.nodeType === 1);
 	}
 
 	function isMessageWanted (message) {

--- a/reporter/cli.js
+++ b/reporter/cli.js
@@ -70,9 +70,11 @@ function reportResult (result) {
 		'\n' +
 		(typeStarts[result.type]) + result.message +
 		'\n' +
-		'   ' + chalk.gray(result.code) +
+		chalk.grey('   ├── ' + result.code) +
 		'\n' +
-		'   ' + chalk.gray(result.context.replace(/\s+/g, ' '))
+		chalk.grey('   ├── ' + result.selector.replace(/\s+/g, ' ')) +
+		'\n' +
+		chalk.grey('   └── ' + result.context.replace(/\s+/g, ' '))
 	);
 }
 

--- a/reporter/csv.js
+++ b/reporter/csv.js
@@ -30,7 +30,7 @@ function reportError (message) {
 }
 
 function reportResults (results) {
-	console.log('"type","code","message","context"');
+	console.log('"type","code","message","context","selector"');
 	results.forEach(reportResult);
 }
 
@@ -39,6 +39,7 @@ function reportResult (result) {
 		JSON.stringify(result.type),
 		JSON.stringify(result.code),
 		JSON.stringify(result.message),
-		JSON.stringify(result.context)
+		JSON.stringify(result.context),
+		JSON.stringify(result.selector)
 	].join(','));
 }

--- a/reporter/html/result.html
+++ b/reporter/html/result.html
@@ -2,5 +2,5 @@
 <li class="result {type}">
 	<h2>{typeLabel}: {message}</h2>
 	<p>{code}</p>
-	<pre>{context}</pre>
+	<pre>{context} (select with "{selector}")</pre>
 </li>

--- a/test/integration/cli-config.js
+++ b/test/integration/cli-config.js
@@ -35,6 +35,7 @@ describe('Pa11y CLI Config', function () {
 				code: 'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
 				context: '<title>bar</title>',
 				message: 'Check that the title element describes the document.',
+				selector: 'html > head > title',
 				type: 'notice',
 				typeCode: 3
 			});

--- a/test/integration/cli-ignore.js
+++ b/test/integration/cli-ignore.js
@@ -35,6 +35,7 @@ describe('Pa11y CLI Ignore', function () {
 				code: 'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
 				context: '<title>Page Title</title>',
 				message: 'Check that the title element describes the document.',
+				selector: 'html > head > title',
 				type: 'notice',
 				typeCode: 3
 			});
@@ -55,6 +56,7 @@ describe('Pa11y CLI Ignore', function () {
 				code: 'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
 				context: '<title>Page Title</title>',
 				message: 'Check that the title element describes the document.',
+				selector: 'html > head > title',
 				type: 'notice',
 				typeCode: 3
 			});

--- a/test/integration/cli-level.js
+++ b/test/integration/cli-level.js
@@ -35,6 +35,7 @@ describe('Pa11y CLI Level', function () {
 				code: 'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
 				context: '<title>Page Title</title>',
 				message: 'Check that the title element describes the document.',
+				selector: 'html > head > title',
 				type: 'notice',
 				typeCode: 3
 			});
@@ -55,6 +56,7 @@ describe('Pa11y CLI Level', function () {
 				code: 'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
 				context: '<title>Page Title</title>',
 				message: 'Check that the title element describes the document.',
+				selector: 'html > head > title',
 				type: 'notice',
 				typeCode: 3
 			});
@@ -62,6 +64,7 @@ describe('Pa11y CLI Level', function () {
 				code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
 				context: '<b>World</b>',
 				message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
+				selector: 'html > body > p > b',
 				type: 'warning',
 				typeCode: 2
 			});
@@ -82,6 +85,7 @@ describe('Pa11y CLI Level', function () {
 				code: 'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
 				context: '<title>Page Title</title>',
 				message: 'Check that the title element describes the document.',
+				selector: 'html > head > title',
 				type: 'notice',
 				typeCode: 3
 			});
@@ -89,6 +93,7 @@ describe('Pa11y CLI Level', function () {
 				code: 'WCAG2AA.Principle3.Guideline3_1.3_1_1.H57.2',
 				context: '<html><head>\n\n    <meta charset="utf-...</html>',
 				message: 'The html element should have a lang or xml:lang attribute which describes the language of the document.',
+				selector: 'html',
 				type: 'error',
 				typeCode: 1
 			});
@@ -96,6 +101,7 @@ describe('Pa11y CLI Level', function () {
 				code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
 				context: '<b>World</b>',
 				message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
+				selector: 'html > body > p > b',
 				type: 'warning',
 				typeCode: 2
 			});

--- a/test/integration/cli-reporter-csv.js
+++ b/test/integration/cli-reporter-csv.js
@@ -29,7 +29,7 @@ describe('Pa11y CLI Reporter (CSV)', function () {
 		});
 
 		it('should respond with the expected output', function () {
-			assert.include(this.lastStdout, '"type","code","message","context"\n"notice","WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2","Check that the title element describes the document.","<title>Page Title</title>"');
+			assert.include(this.lastStdout, '"type","code","message","context","selector"\n"notice","WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2","Check that the title element describes the document.","<title>Page Title</title>","html > head > title"');
 		});
 
 	});

--- a/test/integration/cli-reporter-json.js
+++ b/test/integration/cli-reporter-json.js
@@ -29,7 +29,7 @@ describe('Pa11y CLI Reporter (JSON)', function () {
 		});
 
 		it('should respond with the expected output', function () {
-			assert.include(this.lastStdout, '[{"code":"WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2","context":"<title>Page Title</title>","message":"Check that the title element describes the document.","type":"notice","typeCode":3}]');
+			assert.include(this.lastStdout, '[{"code":"WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2","context":"<title>Page Title</title>","message":"Check that the title element describes the document.","selector":"html > head > title","type":"notice","typeCode":3}]');
 		});
 
 	});

--- a/test/integration/cli-selector.js
+++ b/test/integration/cli-selector.js
@@ -20,7 +20,7 @@
 var assert = require('proclaim');
 var describeCliCall = require('./helper/describe-cli-call');
 
-describe('Pa11y CLI Basic', function () {
+describe('Pa11y CLI Selectors', function () {
 
 	describeCliCall('/selectors', [], {}, function () {
 

--- a/test/integration/cli-selector.js
+++ b/test/integration/cli-selector.js
@@ -22,57 +22,7 @@ var describeCliCall = require('./helper/describe-cli-call');
 
 describe('Pa11y CLI Basic', function () {
 
-	describeCliCall('/notices', [], {}, function () {
-
-		it('should respond with an exit code of `0`', function () {
-			assert.strictEqual(this.lastExitCode, 0);
-		});
-
-		it('should respond with the expected messages', function () {
-			assert.isArray(this.lastJsonResponse);
-			assert.lengthEquals(this.lastJsonResponse, 1);
-			assert.deepEqual(this.lastJsonResponse[0], {
-				code: 'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
-				context: '<title>Page Title</title>',
-				message: 'Check that the title element describes the document.',
-				selector: 'html > head > title',
-				type: 'notice',
-				typeCode: 3
-			});
-		});
-
-	});
-
-	describeCliCall('/warnings', [], {}, function () {
-
-		it('should respond with an exit code of `0`', function () {
-			assert.strictEqual(this.lastExitCode, 0);
-		});
-
-		it('should respond with the expected messages', function () {
-			assert.isArray(this.lastJsonResponse);
-			assert.lengthEquals(this.lastJsonResponse, 2);
-			assert.deepEqual(this.lastJsonResponse[0], {
-				code: 'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
-				context: '<title>Page Title</title>',
-				message: 'Check that the title element describes the document.',
-				selector: 'html > head > title',
-				type: 'notice',
-				typeCode: 3
-			});
-			assert.deepEqual(this.lastJsonResponse[1], {
-				code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
-				context: '<b>World</b>',
-				message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
-				selector: 'html > body > p > b',
-				type: 'warning',
-				typeCode: 2
-			});
-		});
-
-	});
-
-	describeCliCall('/errors', [], {}, function () {
+	describeCliCall('/selectors', [], {}, function () {
 
 		it('should respond with an exit code of `2`', function () {
 			assert.strictEqual(this.lastExitCode, 2);
@@ -80,7 +30,7 @@ describe('Pa11y CLI Basic', function () {
 
 		it('should respond with the expected messages', function () {
 			assert.isArray(this.lastJsonResponse);
-			assert.lengthEquals(this.lastJsonResponse, 3);
+			assert.lengthEquals(this.lastJsonResponse, 5);
 			assert.deepEqual(this.lastJsonResponse[0], {
 				code: 'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
 				context: '<title>Page Title</title>',
@@ -101,7 +51,23 @@ describe('Pa11y CLI Basic', function () {
 				code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
 				context: '<b>World</b>',
 				message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
-				selector: 'html > body > p > b',
+				selector: 'html > body > p:nth-child(1) > b',
+				type: 'warning',
+				typeCode: 2
+			});
+			assert.deepEqual(this.lastJsonResponse[3], {
+				code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
+				context: '<b>foo</b>',
+				message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
+				selector: '#foo > b',
+				type: 'warning',
+				typeCode: 2
+			});
+			assert.deepEqual(this.lastJsonResponse[4], {
+				code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
+				context: '<b id="bar">bar</b>',
+				message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
+				selector: '#bar',
 				type: 'warning',
 				typeCode: 2
 			});

--- a/test/integration/cli-standard.js
+++ b/test/integration/cli-standard.js
@@ -48,6 +48,7 @@ describe('Pa11y CLI Standard', function () {
 				code: 'WCAG2A.Principle2.Guideline2_4.2_4_2.H25.2',
 				context: '<title>Page Title</title>',
 				message: 'Check that the title element describes the document.',
+				selector: 'html > head > title',
 				type: 'notice',
 				typeCode: 3
 			});
@@ -68,6 +69,7 @@ describe('Pa11y CLI Standard', function () {
 				code: 'WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2',
 				context: '<title>Page Title</title>',
 				message: 'Check that the title element describes the document.',
+				selector: 'html > head > title',
 				type: 'notice',
 				typeCode: 3
 			});
@@ -88,6 +90,7 @@ describe('Pa11y CLI Standard', function () {
 				code: 'WCAG2AAA.Principle2.Guideline2_4.2_4_2.H25.2',
 				context: '<title>Page Title</title>',
 				message: 'Check that the title element describes the document.',
+				selector: 'html > head > title',
 				type: 'notice',
 				typeCode: 3
 			});

--- a/test/integration/mock/html/selectors.html
+++ b/test/integration/mock/html/selectors.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+
+    <meta charset="utf-8"/>
+    <title>Page Title</title>
+
+</head>
+<body>
+
+	<p>Hello <b>World</b>!</p>
+
+	<p id="foo">paragraph <b>foo</b></p>
+
+	<p>paragraph <b id="bar">bar</b></p>
+
+</body>
+</html>

--- a/test/unit/lib/inject.js
+++ b/test/unit/lib/inject.js
@@ -91,6 +91,7 @@ describe('lib/inject', function () {
 					code: 'foo-code',
 					context: '<element>foo inner</element>',
 					message: 'foo message',
+					selector: '',
 					type: 'error',
 					typeCode: 1
 				},
@@ -98,6 +99,7 @@ describe('lib/inject', function () {
 					code: 'bar-code',
 					context: '<element>bar inner at more than 30 chara...</element>',
 					message: 'bar message',
+					selector: '',
 					type: 'warning',
 					typeCode: 2
 				},
@@ -105,6 +107,7 @@ describe('lib/inject', function () {
 					code: 'baz-code',
 					context: '<element with=\"loads of attributes\" that=\"push the total outerHTML length\" to=\"more than we really want to send back to Node.js\" this=\"is getting kind of silly now, I really want to stop writing dummy text to push the length of this element out\">baz ...',
 					message: 'baz message',
+					selector: '',
 					type: 'notice',
 					typeCode: 3
 				}
@@ -142,6 +145,7 @@ describe('lib/inject', function () {
 					code: 'bar-code',
 					context: '<element>bar inner at more than 30 chara...</element>',
 					message: 'bar message',
+					selector: '',
 					type: 'warning',
 					typeCode: 2
 				}
@@ -179,6 +183,7 @@ describe('lib/inject', function () {
 					code: 'foo-code',
 					context: '<element>foo inner</element>',
 					message: 'foo message',
+					selector: '',
 					type: 'error',
 					typeCode: 1
 				}


### PR DESCRIPTION
Add the element's CSS selector to the results, completing #77 (css selectors were easier than XPath)