### PR TITLE
Allow specificing the HTML_CodeSniffer Library location

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Usage: pa11y [options] <url>
     -p, --port <port>          the port to run PhantomJS on
     -t, --timeout <ms>         the timeout in milliseconds
     -d, --debug                output debug messages
+    -h, --htmlcs <url/path>    The url or path to the HTML_CodeSniffer Library
 ```
 
 ### Running Tests

--- a/bin/pa11y
+++ b/bin/pa11y
@@ -37,6 +37,7 @@ function configureProgram (program) {
 		.option('-p, --port <port>', 'the port to run PhantomJS on')
 		.option('-t, --timeout <ms>', 'the timeout in milliseconds')
 		.option('-d, --debug', 'output debug messages')
+		.option('-h, --htmlcs <url>', 'specify a URL or path to source HTML_CodeSniffer from. Default: local', 'local')
 		.parse(process.argv);
 	program.url = program.args[0];
 }
@@ -73,6 +74,7 @@ function processOptions (program) {
 		phantom: {
 			port: program.port
 		},
+		htmlcs: program.htmlcs,
 		standard: program.standard,
 		timeout: program.timeout
 	});

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -101,12 +101,32 @@ function testPage (options, browser, page, done) {
 
 		injectCodeSniffer: function (next) {
 			options.log.debug('Injecting HTML CodeSniffer (' + (Date.now() - startTime) + 'ms)');
-			page.injectJs(__dirname + '/vendor/HTMLCS.js', function (injected) {
-				if (!injected) {
-					return next(new Error('Pa11y was unable to inject scripts into the page'));
-				}
-				next();
-			});
+
+			var location = __dirname + '/vendor/HTMLCS.js';
+			var fs = require('fs');
+
+			if (options.htmlcs !== 'local') {
+				location = options.htmlcs;
+			}
+
+			if (fs.existsSync(location)) {
+				// it is a local file
+				page.injectJs(location, function (injected) {
+					if (!injected) {
+						return next(new Error('Pa11y was unable to inject scripts into the page'));
+					}
+					next();
+				});
+			}
+			else {
+				// it is probably a URL, so try to include it
+				page.includeJs(location, function (included) {
+					if (!included) {
+						return next(new Error('Pa11y was unable to include scripts into the page'));
+					}
+					next();
+				});
+			}
 		},
 
 		injectPa11y: function (next) {

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -230,6 +230,7 @@ describe('lib/pa11y', function () {
 					'BAZ',
 					'qux'
 				],
+				htmlcs: 'local',
 				standard: 'Section508'
 			};
 


### PR DESCRIPTION
We are using a customized fork of the HTML_CodeSniffer Library, so being forced to use the included one is a big step backwards for us.