### PR TITLE
Wait a little bit to let the page finish loading before testing

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -126,7 +126,11 @@ function testPage (options, browser, page, done) {
 				if (typeof window.callPhantom !== 'function') {
 					return new Error('Pa11y could not report back to PhantomJS');
 				}
-				injectPa11y(window, options, window.callPhantom);
+
+				window.setTimeout(function () {
+					//Wait a bit to let the page finish loading
+					injectPa11y(window, options, window.callPhantom);
+				}, 500);
 			}, next, {
 				ignore: options.ignore,
 				standard: options.standard


### PR DESCRIPTION
I'm not sure what the best way to handle this might be.

We have a case where a javascript widget injects some CSS to style otherwise inaccessible content (contrast ratio).  However, the javascript widget injects the CSS just after page load, so when pa11y tests the page, the content is flagged as an error.  If you run the html_codesniffer bookmarket, everything is okay because the CSS had had a chance to be injected.

The point is, we don't know when JS will inject things make make things accessible or inaccessible.  The hope here is to add a small buffer to handle the majority of edge cases.  

Ideas and feedback is very welcome.  :)