### PR TITLE
Allow specifying the HTML CodeSniffer Library location

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -18,10 +18,11 @@ The command-line interface in 2.0 is similar to 1.0, but there are a few key cha
   - Reporters no longer handle the way pa11y exits, this is controlled through the new `--level` flag
   - Custom reporters now have a different API, see the [README](README.md) for more information
   - The file specified by the `--config` flag now expects JSON in a different format. See [configuration](#configuration)
-  - The `--htmlcs` flag has been removed, HTML CodeSniffer is now loaded from a local file
+  - The `--htmlcs` flag shorthand has been changed to `-H`
   - The `--useragent` flag has been removed, this is now managed through the config file
   - The `--viewport` flag has been removed, this is now managed through the config file
   - The `--strict` flag has been removed, this is controlled through the new `--level` flag
+  - HTML CodeSniffer is now loaded from a local file by default so tests can be run offline
 
 ### JavaScript Interface
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,18 @@ The results that get passed into your test callback come from HTML CodeSniffer, 
 Configuration
 -------------
 
+### `htmlcs` (string)
+
+The path or URL to source HTML CodeSniffer from.
+
+```js
+pa11y({
+    htmlcs: 'http://squizlabs.github.io/HTML_CodeSniffer/build/HTMLCS.js'
+});
+```
+
+Defaults to a local copy of HTML CodeSniffer, found in [lib/vendor/HTMLCS.js](lib/vendor/HTMLCS.js).
+
 ### `ignore` (array)
 
 An array of result codes and types that you'd like to ignore. You can find the codes for each rule in the console output and the types are `error`, `warning`, and `notice`.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Usage: pa11y [options] <url>
     -p, --port <port>          the port to run PhantomJS on
     -t, --timeout <ms>         the timeout in milliseconds
     -d, --debug                output debug messages
-    -h, --htmlcs <url/path>    The url or path to the HTML_CodeSniffer Library
+    -H, --htmlcs <url/path>    the URL or path to source HTML_CodeSniffer from
 ```
 
 ### Running Tests

--- a/bin/pa11y
+++ b/bin/pa11y
@@ -37,7 +37,7 @@ function configureProgram (program) {
 		.option('-p, --port <port>', 'the port to run PhantomJS on')
 		.option('-t, --timeout <ms>', 'the timeout in milliseconds')
 		.option('-d, --debug', 'output debug messages')
-		.option('-h, --htmlcs <url>', 'specify a URL or path to source HTML_CodeSniffer from. Default: local', 'local')
+		.option('-H, --htmlcs <url>', 'the URL or path to source HTML_CodeSniffer from')
 		.parse(process.argv);
 	program.url = program.args[0];
 }
@@ -69,12 +69,12 @@ function runProgram (program) {
 
 function processOptions (program) {
 	var options = extend(true, {}, loadConfig(program.config), {
+		htmlcs: program.htmlcs,
 		ignore: (program.ignore ? program.ignore.split(';') : undefined),
 		log: loadReporter(program.reporter),
 		phantom: {
 			port: program.port
 		},
-		htmlcs: program.htmlcs,
 		standard: program.standard,
 		timeout: program.timeout
 	});

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -25,6 +25,7 @@ var trufflerPkg = require('truffler/package.json');
 
 module.exports = pa11y;
 module.exports.defaults = {
+	htmlcs: __dirname + '/vendor/HTMLCS.js',
 	ignore: [],
 	log: {
 		begin: function () {},
@@ -101,28 +102,20 @@ function testPage (options, browser, page, done) {
 
 		injectCodeSniffer: function (next) {
 			options.log.debug('Injecting HTML CodeSniffer (' + (Date.now() - startTime) + 'ms)');
-
-			var location = __dirname + '/vendor/HTMLCS.js';
-			var fs = require('fs');
-
-			if (options.htmlcs !== 'local') {
-				location = options.htmlcs;
-			}
-
-			if (fs.existsSync(location)) {
-				// it is a local file
-				page.injectJs(location, function (injected) {
-					if (!injected) {
-						return next(new Error('Pa11y was unable to inject scripts into the page'));
+			if (/^(https?|file):\/\//.test(options.htmlcs)) {
+				// Include remote URL
+				page.includeJs(options.htmlcs, function (included) {
+					if (!included) {
+						return next(new Error('Pa11y was unable to include scripts in the page'));
 					}
 					next();
 				});
 			}
 			else {
-				// it is probably a URL, so try to include it
-				page.includeJs(location, function (included) {
-					if (!included) {
-						return next(new Error('Pa11y was unable to include scripts into the page'));
+				// Inject local file
+				page.injectJs(options.htmlcs, function (injected) {
+					if (!injected) {
+						return next(new Error('Pa11y was unable to inject scripts into the page'));
 					}
 					next();
 				});

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -58,6 +58,10 @@ describe('lib/pa11y', function () {
 			defaults = pa11y.defaults;
 		});
 
+		it('should have an `htmlcs` property', function () {
+			assert.strictEqual(defaults.htmlcs, path.resolve(__dirname + '/../../..') + '/lib/vendor/HTMLCS.js');
+		});
+
 		it('should have an `ignore` property', function () {
 			assert.isArray(defaults.ignore);
 		});
@@ -230,7 +234,6 @@ describe('lib/pa11y', function () {
 					'BAZ',
 					'qux'
 				],
-				htmlcs: 'local',
 				standard: 'Section508'
 			};
 
@@ -271,10 +274,28 @@ describe('lib/pa11y', function () {
 
 		it('should inject HTML CodeSniffer', function (done) {
 			testFunction(phantom.mockBrowser, phantom.mockPage, function () {
-				var inject = phantom.mockPage.injectJs.withArgs(path.resolve(__dirname, '../../../lib') + '/vendor/HTMLCS.js');
+				var inject = phantom.mockPage.injectJs.withArgs(pa11y.defaults.htmlcs);
 				assert.calledOnce(inject);
 				assert.isFunction(inject.firstCall.args[1]);
+				assert.notCalled(phantom.mockPage.includeJs);
 				done();
+			});
+		});
+
+		it('should include a remote HTML CodeSniffer if specified', function (done) {
+			options = {
+				htmlcs: 'http://foo.com/HTMLCS.js'
+			};
+			truffler.reset();
+			pa11y(options, function () {
+				testFunction = truffler.firstCall.args[0].testFunction;
+				testFunction(phantom.mockBrowser, phantom.mockPage, function () {
+					var include = phantom.mockPage.includeJs.withArgs(options.htmlcs);
+					assert.calledOnce(include);
+					assert.isFunction(include.firstCall.args[1]);
+					assert.notCalled(phantom.mockPage.injectJs.withArgs(pa11y.defaults.htmlcs));
+					done();
+				});
 			});
 		});
 
@@ -358,6 +379,22 @@ describe('lib/pa11y', function () {
 				assert.isNotNull(error);
 				assert.strictEqual(error.message, 'Pa11y was unable to inject scripts into the page');
 				done();
+			});
+		});
+
+		it('should callback with an error if a remote HTML CodeSniffer does not include properly', function (done) {
+			options = {
+				htmlcs: 'http://foo.com/HTMLCS.js'
+			};
+			truffler.reset();
+			phantom.mockPage.includeJs.withArgs('http://foo.com/HTMLCS.js').yieldsAsync(false);
+			pa11y(options, function () {
+				testFunction = truffler.firstCall.args[0].testFunction;
+				testFunction(phantom.mockBrowser, phantom.mockPage, function (error) {
+					assert.isNotNull(error);
+					assert.strictEqual(error.message, 'Pa11y was unable to include scripts in the page');
+					done();
+				});
 			});
 		});
 

--- a/test/unit/mock/phantom.js
+++ b/test/unit/mock/phantom.js
@@ -27,6 +27,7 @@ var phantom = module.exports = {
 	mockPage: {
 		close: sinon.stub(),
 		evaluate: sinon.stub().callsArgAsync(1),
+		includeJs: sinon.stub().yieldsAsync(true),
 		injectJs: sinon.stub().yieldsAsync(true),
 		open: sinon.stub(),
 		set: sinon.stub()


### PR DESCRIPTION
Includes code from #81. @mfairchild365, do you fancy taking a look at this as well? Does it still suit your needs? One notable change is that I had to change the command-line flag to `-H` as `-h` was conflicting with `--help`.