### PR TITLE
Add an option which makes pa11y wait for a configured amount of time before running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Usage: pa11y [options] <url>
     -c, --config <path>        a JSON config file
     -p, --port <port>          the port to run PhantomJS on
     -t, --timeout <ms>         the timeout in milliseconds
+    -w, --wait <ms>            the time to wait before running tests in milliseconds
     -d, --debug                output debug messages
     -H, --htmlcs <url/path>    the URL or path to source HTML_CodeSniffer from
 ```

--- a/README.md
+++ b/README.md
@@ -403,6 +403,18 @@ pa11y({
 
 Defaults to `30000`.
 
+### `wait` (number)
+
+The time in milliseconds to wait before running HTML CodeSniffer on the page.
+
+```js
+pa11y({
+    wait: 500
+});
+```
+
+Defaults to `0`.
+
 
 Examples
 --------

--- a/bin/pa11y
+++ b/bin/pa11y
@@ -36,6 +36,7 @@ function configureProgram (program) {
 		.option('-c, --config <path>', 'a JSON config file', './pa11y.json')
 		.option('-p, --port <port>', 'the port to run PhantomJS on')
 		.option('-t, --timeout <ms>', 'the timeout in milliseconds')
+		.option('-w, --wait <ms>', 'the time to wait before running tests in milliseconds')
 		.option('-d, --debug', 'output debug messages')
 		.option('-H, --htmlcs <url>', 'the URL or path to source HTML_CodeSniffer from')
 		.parse(process.argv);
@@ -76,7 +77,8 @@ function processOptions (program) {
 			port: program.port
 		},
 		standard: program.standard,
-		timeout: program.timeout
+		timeout: program.timeout,
+		wait: program.wait
 	});
 	if (!program.debug) {
 		options.log.debug = function () {};

--- a/lib/inject.js
+++ b/lib/inject.js
@@ -24,7 +24,7 @@ function injectPa11y (window, options, done) {
 		3: 'notice'
 	};
 
-	runCodeSniffer();
+	setTimeout(runCodeSniffer, options.wait);
 
 	function runCodeSniffer () {
 		try {

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -47,7 +47,8 @@ module.exports.defaults = {
 		}
 	},
 	standard: 'WCAG2AA',
-	timeout: 30000
+	timeout: 30000,
+	wait: 0
 };
 
 function pa11y (options, done) {
@@ -74,13 +75,20 @@ function validateOptions (options) {
 	if (typeof options.timeout !== 'number' && !/^\d+$/.test(options.timeout)) {
 		return new Error('Timeout must be numeric');
 	}
+	if (typeof options.wait !== 'number' && !/^\d+$/.test(options.wait)) {
+		return new Error('Wait time must be numeric');
+	}
 }
 
 function testPage (options, browser, page, done) {
 
 	var pageCallback = once(function (result) {
 		clearTimeout(timer);
-		options.log.debug('Test running completed (' + (Date.now() - startTime) + 'ms)');
+		options.log.debug(
+			'Test running completed (' +
+			(Date.now() - startTime - options.wait) +
+			'ms)'
+		);
 		if (result instanceof Error) {
 			return done(result);
 		}
@@ -134,6 +142,9 @@ function testPage (options, browser, page, done) {
 
 		run: function (next) {
 			options.log.debug('Running Pa11y on the page (' + (Date.now() - startTime) + 'ms)');
+			if (options.wait > 0) {
+				options.log.debug('Waiting for ' + options.wait + 'ms (pausing timer)');
+			}
 			page.evaluate(function (options) {
 				/* global injectPa11y: true, window: true */
 				if (typeof window.callPhantom !== 'function') {
@@ -142,7 +153,8 @@ function testPage (options, browser, page, done) {
 				injectPa11y(window, options, window.callPhantom);
 			}, next, {
 				ignore: options.ignore,
-				standard: options.standard
+				standard: options.standard,
+				wait: options.wait
 			});
 		}
 

--- a/test/unit/lib/inject.js
+++ b/test/unit/lib/inject.js
@@ -26,7 +26,8 @@ describe('lib/inject', function () {
 		window = require('../mock/window');
 		options = {
 			ignore: [],
-			standard: 'FOO-STANDARD'
+			standard: 'FOO-STANDARD',
+			wait: 0
 		};
 		inject = require('../../../lib/inject');
 	});
@@ -39,6 +40,17 @@ describe('lib/inject', function () {
 		inject(window, options, function () {
 			assert.calledOnce(window.HTMLCS.process);
 			assert.calledWith(window.HTMLCS.process, 'FOO-STANDARD', window.document);
+			done();
+		});
+	});
+
+	it('should wait before processing the page if `options.wait` is set', function (done) {
+		// Note: this test isn't particularly reliable, revisit some time
+		var start = Date.now();
+		options.wait = 10;
+		inject(window, options, function () {
+			var end = Date.now() - start;
+			assert.greaterThanOrEqual(end, 10);
 			done();
 		});
 	});

--- a/test/unit/lib/pa11y.js
+++ b/test/unit/lib/pa11y.js
@@ -122,6 +122,10 @@ describe('lib/pa11y', function () {
 			assert.strictEqual(defaults.timeout, 30000);
 		});
 
+		it('should have a `wait` property', function () {
+			assert.strictEqual(defaults.wait, 0);
+		});
+
 	});
 
 	it('should default the options', function (done) {
@@ -154,6 +158,17 @@ describe('lib/pa11y', function () {
 		pa11y(options, function (error) {
 			assert.isNotNull(error);
 			assert.strictEqual(error.message, 'Timeout must be numeric');
+			done();
+		});
+	});
+
+	it('should callback with an error if `options.wait` is invalid', function (done) {
+		var options = {
+			wait: 'foo'
+		};
+		pa11y(options, function (error) {
+			assert.isNotNull(error);
+			assert.strictEqual(error.message, 'Wait time must be numeric');
 			done();
 		});
 	});
@@ -234,7 +249,8 @@ describe('lib/pa11y', function () {
 					'BAZ',
 					'qux'
 				],
-				standard: 'Section508'
+				standard: 'Section508',
+				wait: 0
 			};
 
 			// Big old nasty mock
@@ -318,7 +334,8 @@ describe('lib/pa11y', function () {
 						'baz',
 						'qux'
 					],
-					standard: 'Section508'
+					standard: 'Section508',
+					wait: 0
 				});
 				done();
 			});


### PR DESCRIPTION
This allows for testing pages after client-side JavaScript has been run. It's not bullet-proof but works for now. Later we may enable execution of arbitrary scripts before the HTML CodeSniffer run which will be a more solid way to do this. Addresses #82.

@mfairchild365, happy with the implementation? Should it solve your issue?