### PR TITLE
Add Markdown reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The command-line tool can report test results in a few different ways using the 
   - `csv`: output test results as comma-separated values
   - `html`: output test results as an HTML document
   - `json`: output test results as a JSON array
+  - `markdown`: output test results as a Markdown document
 
 You can also write and publish your own reporters. Pa11y looks for reporters in the core library, your `node_modules` folder (with a naming pattern), and the current working directory. The first reporter found will be loaded. So with this command:
 

--- a/reporter/markdown.js
+++ b/reporter/markdown.js
@@ -1,0 +1,88 @@
+// // This file is part of pa11y.
+// //
+// // pa11y is free software: you can redistribute it and/or modify
+// // it under the terms of the GNU General Public License as published by
+// // the Free Software Foundation, either version 3 of the License, or
+// // (at your option) any later version.
+// //
+// // pa11y is distributed in the hope that it will be useful,
+// // but WITHOUT ANY WARRANTY; without even the implied warranty of
+// // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// // GNU General Public License for more details.
+// //
+// // You should have received a copy of the GNU General Public License
+// // along with pa11y.  If not, see <http://www.gnu.org/licenses/>.
+
+'use strict';
+
+var typeStarts = {
+	error: '__Error:__ ',
+	notice: '__Notice:__ ',
+	unknown: '',
+	warning: '__Warning:__ '
+};
+
+module.exports = {
+	begin: reportBegin,
+	error: reportError,
+	debug: emptyFunction,
+	info: emptyFunction,
+	results: reportResults
+};
+
+function reportBegin () {
+	console.log('# Welcome to Pa11y\n');
+}
+
+function reportResults (results, url) {
+	console.log('## Results for ' + url + ':');
+	if (results.length === 0) {
+		return console.log('\n * No errors found!');
+	}
+	results.forEach(reportResult);
+	console.log('');
+	reportTotals(results);
+}
+
+function reportResult (result) {
+	console.log(
+		'* ' + typeStarts[result.type] + result.message +
+		'\n' +
+		' * ' + result.code +
+		'\n' +
+		' * ' + result.selector.replace(/\s+/g, ' ') +
+		'\n' +
+		' * `' + result.context.replace(/\s+/g, ' ') + '`' +
+		'\n'
+	);
+}
+
+function reportTotals (results) {
+	var totalErrors = results.filter(isError).length;
+	var totalNotices = results.filter(isNotice).length;
+	var totalWarnings = results.filter(isWarning).length;
+	console.log('## Summary:');
+	console.log(
+		'* ' + totalErrors + ' Errors' + '\n' +
+		'* ' + totalWarnings + ' Warnings' + '\n' +
+		'* ' + totalNotices + ' Notices' + '\n'
+	);
+}
+
+function reportError (message) {
+	console.error(message);
+}
+
+function emptyFunction () {}
+
+function isError (result) {
+	return (result.type === 'error');
+}
+
+function isNotice (result) {
+	return (result.type === 'notice');
+}
+
+function isWarning (result) {
+	return (result.type === 'warning');
+}

--- a/test/integration/cli-reporter-markdown.js
+++ b/test/integration/cli-reporter-markdown.js
@@ -1,0 +1,37 @@
+// This file is part of pa11y.
+//
+// pa11y is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// pa11y is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with pa11y.  If not, see <http://www.gnu.org/licenses/>.
+
+// jshint maxstatements: false
+// jscs:disable maximumLineLength
+'use strict';
+
+var assert = require('proclaim');
+var describeCliCall = require('./helper/describe-cli-call');
+
+describe('Pa11y CLI Reporter (Markdown)', function () {
+
+	describeCliCall('/notices', ['--reporter', 'markdown'], {}, function () {
+
+		it('should respond with an exit code of `0`', function () {
+			assert.strictEqual(this.lastExitCode, 0);
+		});
+
+		it('should respond with the expected output', function () {
+			assert.include(this.lastStdout, '# Welcome to Pa11y\n\n## Results for localhost:3131/notices:\n* __Notice:__ Check that the title element describes the document.\n * WCAG2AA.Principle2.Guideline2_4.2_4_2.H25.2\n * html > head > title\n * `<title>Page Title</title>`\n\n\n## Summary:\n* 0 Errors\n* 0 Warnings\n* 1 Notices\n');
+		});
+
+	});
+
+});


### PR DESCRIPTION
Useful for generating reports that can be easily shared across GitHub Issues, Jekyll blogs, or anywhere else in the Markdown universe.