### PR TITLE
Adding an option for running JS before testing

### DIFF
--- a/bin/pa11y
+++ b/bin/pa11y
@@ -70,6 +70,10 @@ function configureProgram(program) {
 			'the time to wait before running tests in milliseconds'
 		)
 		.option(
+			'-I, --injectJs <path>',
+			'a script that can be injected into phantomjs before pa11y runs'
+		)
+		.option(
 			'-d, --debug',
 			'output debug messages'
 		)
@@ -125,7 +129,8 @@ function processOptions(program) {
 		},
 		standard: program.standard,
 		timeout: program.timeout,
-		wait: program.wait
+		wait: program.wait,
+		injectJs: program.injectJs
 	});
 	if (!program.debug) {
 		options.log.debug = function() {};

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -47,7 +47,8 @@ module.exports.defaults = {
 		}
 	},
 	standard: 'WCAG2AA',
-	wait: 0
+	wait: 0,
+	injectJs: null
 };
 
 function pa11y(options) {
@@ -55,6 +56,7 @@ function pa11y(options) {
 	if (['Section508', 'WCAG2A', 'WCAG2AA', 'WCAG2AAA'].indexOf(options.standard) === -1) {
 		throw new Error('Standard must be one of Section508, WCAG2A, WCAG2AA, WCAG2AAA');
 	}
+
 	return truffler(options, testPage.bind(null, options));
 }
 
@@ -73,11 +75,35 @@ function testPage(options, browser, page, done) {
 		if (result.error) {
 			return done(new Error(result.error));
 		}
+
 		done(null, result.messages);
 	});
 
 	async.waterfall([
+		function(next) {
+			if (options.injectJs) {
+				options.log.debug('Injecting supplied JavaScript');
+				page.injectJs(options.injectJs, function(error, injected) {
+					if (error) {
+						return next(error);
+					}
+					if (!injected) {
+						return next(new Error('Pa11y was unable to inject supplied scripts into the page'));
+					}
 
+				});
+
+				page.onConsoleMessage = function(msg) {
+					msg = msg.toLowerCase().replace(/ /g, '');
+					if (msg === 'pa11y:scriptcomplete') {
+						options.log.debug('Supplied JavaScript finished running');
+						next();
+					}
+				};
+			} else {
+				next();
+			}
+		},
 		// Inject HTML CodeSniffer
 		function(next) {
 			options.log.debug('Injecting HTML CodeSniffer');


### PR DESCRIPTION
DO NOT MERGE
I wanted to get this PR in early for discussion but its not complete yet and ready for merging.

This is an attempt to add the new functionality suggested in issue #98.

This will add the `--injectJs` option to pass in a file path to a
JavaScript file to be run pa11y is run.

That JavaScript file has to `console.log('pa11y: script complete')`
before pa11y will be run.

I am not 100% sure how I feel about this `console.log` approach but it
felt like it kept the supplied JS simple and without any phantomjs
knowledge required compared to the callback approach.

DO NOT MERGE
Tests still need to be written.