### PR TITLE
Allow more standards. Do not hardcode the list

### DIFF
--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -47,13 +47,14 @@ module.exports.defaults = {
 		}
 	},
 	standard: 'WCAG2AA',
+	allowedStandards: ['Section508', 'WCAG2A', 'WCAG2AA', 'WCAG2AAA'],
 	wait: 0
 };
 
 function pa11y(options) {
 	options = defaultOptions(options);
-	if (['Section508', 'WCAG2A', 'WCAG2AA', 'WCAG2AAA'].indexOf(options.standard) === -1) {
-		throw new Error('Standard must be one of Section508, WCAG2A, WCAG2AA, WCAG2AAA');
+	if (options.allowedStandards.indexOf(options.standard) === -1) {
+		throw new Error('Standard must be one of ' + options.allowedStandards.join(', '));
 	}
 	return truffler(options, testPage.bind(null, options));
 }


### PR DESCRIPTION
This is necessary when we add our own standards and would like to use them. This is not a feature, this is kind of a bug fix :-).

Cheers!