### PR TITLE
Allows JavaScript to be run before running pa11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Usage: pa11y [options] <url>
     -l, --level <level>        the level of message to fail on (exit with code 2): error, warning, notice
     -T, --threshold <name>     the number of individual errors, warnings, or notices to permit before failing
     -i, --ignore <ignore>      types and codes of messages to ignore, a repeatable value or separated by semi-colons
-    -c, --config <path>        a JSON config file
+    -c, --config <path>        a JSON or JavaScript config file
     -p, --port <port>          the port to run PhantomJS on
     -t, --timeout <ms>         the timeout in milliseconds
     -w, --wait <ms>            the time to wait before running tests in milliseconds
@@ -549,7 +549,7 @@ Common questions about pa11y are answered here.
 
 ### How do I set cookies on a tested page?
 
-Use the `page.headers` option either in your JS code or in your JSON config file:
+Use the `page.headers` option either in your JS code or in your config file:
 
 ```js
 pa11y({
@@ -563,7 +563,7 @@ pa11y({
 
 ### How can pa11y log in if my site's behind basic auth?
 
-Use the `page.settings` option either in your JS code or in your JSON config file to set a username and password:
+Use the `page.settings` option either in your JS code or in your config file to set a username and password:
 
 ```js
 pa11y({
@@ -578,7 +578,7 @@ pa11y({
 
 ### How can pa11y log in if my site has a log in form?
 
-Use the `beforeScript` option either in your JS code or in your JSON config file to input login details and submit the form.
+Use the `beforeScript` option either in your JS code or in your config file to input login details and submit the form.
 Once the form has been submitted you will also have to wait until the page you want to test has loaded before calling `next` to run pa11y.
 
 ```js
@@ -619,7 +619,7 @@ pa11y({
 
 ### How can I use pa11y with a proxy server?
 
-Use the `phantom.parameters` option either in your JS code or in your JSON config file:
+Use the `phantom.parameters` option either in your JS code or in your config file:
 
 ```js
 pa11y({
@@ -637,7 +637,7 @@ These match PhantomJS [command-line parameters][phantom-cli]. `proxy-type` can b
 
 ### How can I simulate a user interaction before running pa11y?
 
-Use the `beforeScript` option either in your JS code or in your JSON config file to simulate the interactions before running pa11y.
+Use the `beforeScript` option either in your JS code or in your config file to simulate the interactions before running pa11y.
 
 In this example, additional content is loaded via ajax when a button is clicked.
 Once the content is loaded the `aria-hidden` atrribute switches from `true` to `false`.

--- a/bin/pa11y
+++ b/bin/pa11y
@@ -56,7 +56,7 @@ function configureProgram(program) {
 		)
 		.option(
 			'-c, --config <path>',
-			'a JSON config file',
+			'a JSON or JavaScript config file',
 			'./pa11y.json'
 		)
 		.option(

--- a/example/before-script/index.js
+++ b/example/before-script/index.js
@@ -1,0 +1,68 @@
+'use strict';
+
+/*
+ * An example to inject a script before pa11y runs
+ * This example logs in to a fictional site
+ * Then it waits until the account page has loaded before running pa11y
+ */
+
+var pa11y = require('../..');
+
+// Create a test instance with some default options
+var test = pa11y({
+
+	// Log what's happening to the console
+	log: {
+		debug: console.log.bind(console),
+		error: console.error.bind(console),
+		info: console.log.bind(console)
+	},
+
+	// A script to be run on the inital page before pa11y is run.
+	// beforeScript accepts three parameters, the page object, the pa11y options and a callback
+	beforeScript: function(page, options, next) {
+
+		// An example function that can be used to make sure changes have been confirmed before continuing to run Pa11y
+		var waitUntil = function(condition, retries, waitOver) {
+			page.evaluate(condition, function(error, result) {
+				if (result || retries < 1) {
+					// Once the changes have taken place continue with pa11y testing
+					waitOver();
+				} else {
+					retries -= 1;
+					setTimeout(function() {
+						waitUntil(condition, retries, waitOver);
+					}, 200);
+				}
+			});
+		};
+
+		// The script to manipulate the page must be run with page.evaluate to be run within the context of the page
+		page.evaluate(function() {
+			var user = document.querySelector('#username');
+			var password = document.querySelector('#password');
+			var submit = document.querySelector('#submit');
+
+			user.value = 'exampleUser';
+			password.value = 'password1234';
+
+			submit.click();
+
+		}, function() {
+
+			// Use the waitUntil function to set the condition, number of retries and the callback
+			waitUntil(function() {
+				return window.location.href === 'http://example.com/myaccount';
+			}, 20, next);
+		});
+	}
+
+});
+
+// Start on the http://example.com/login where the beforeScript will be injected
+test.run('example.com/login', function(error, result) {
+	if (error) {
+		return console.error(error.message);
+	}
+	console.log(result);
+});

--- a/lib/pa11y.js
+++ b/lib/pa11y.js
@@ -25,6 +25,7 @@ var trufflerPkg = require('truffler/package.json');
 
 module.exports = pa11y;
 module.exports.defaults = {
+	beforeScript: null,
 	htmlcs: __dirname + '/vendor/HTMLCS.js',
 	ignore: [],
 	log: {
@@ -78,7 +79,14 @@ function testPage(options, browser, page, done) {
 	});
 
 	async.waterfall([
+		function(next) {
+			if (typeof options.beforeScript !== 'function') {
+				return next();
+			}
 
+			options.log.debug('Running beforeScript');
+			options.beforeScript(page, options, next);
+		},
 		// Inject HTML CodeSniffer
 		function(next) {
 			options.log.debug('Injecting HTML CodeSniffer');
@@ -117,6 +125,7 @@ function testPage(options, browser, page, done) {
 				if (!injected) {
 					return next(new Error('Pa11y was unable to inject scripts into the page'));
 				}
+
 				next();
 			});
 		},


### PR DESCRIPTION
This allows additional javascript to be run on the page before the pa11y
tests are run.

This will enable people to perform stuff such as page manipulations or
to login as a user before testing the page with pa11y.